### PR TITLE
Refactor mock object to make it cleaner and consistent

### DIFF
--- a/tests/mocks/mock_trials_data.py
+++ b/tests/mocks/mock_trials_data.py
@@ -1,26 +1,15 @@
 import pandas as pd
+from clashboard.clinical_trials_data import ClinicalTrialsData
 
 
-class MockClinicalTrialsData:
-
-    def __init__(self, filename='trial_test_data.csv'):
+class MockClinicalTrialsData(ClinicalTrialsData):
+    """
+    This class allows for easy GUI testing.  Rather than load data
+    from the database, we load it from a CSV file.
+    """
+    def __init__(self, filename):
+        super().__init__()
         self.file = filename
-        self.studies = None
-        self.curr_group = ''
-        self.type_counts = None
 
     def populate_tables(self):
         self.studies = pd.read_csv(self.file)
-
-    def set_group_by(self, attribute):
-        self.curr_group = attribute
-        self.type_counts = self.studies.groupby(self.curr_group).size()
-
-    def get_group_by(self):
-        return self.curr_group
-
-    def get_labels(self):
-        return self.type_counts.index
-
-    def get_values(self):
-        return self.type_counts.values

--- a/tests/mocks/test_mock_trials_data.py
+++ b/tests/mocks/test_mock_trials_data.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from tests.mocks.mock_trials_data import MockClinicalTrialsData
+
+TEST_DATA_DIR = Path(__file__).resolve().parent.parent / 'data'
+
+
+def test_data_read_from_standard_file():
+    file_path = '{}/trial_test_data.csv'.format(TEST_DATA_DIR)
+    mctd = MockClinicalTrialsData(file_path)
+    mctd.populate_tables()
+    mctd.set_group_by('study_type')
+    assert mctd.get_group_by() == 'study_type'
+    assert mctd.get_values() == [9, 1]
+    labels = ['Interventional', 'Observational [Patient Registry]']
+    assert mctd.get_labels() == labels
+    assert mctd.get_current_filters() == []


### PR DESCRIPTION

@Zambelli24: The previous version had an error because our production version converted the array to a list and the mock version did not.  As I was changing it, I realized that I was simply reproducing the code from the original.  This version that uses inheritance is better.  

I think there is an opportunity to do something interesting with fixtures to allow people to build up a desired data set by combining fixtures.  That's an improvement for another day.  This PR gets the two versions to be consistent, which is really important right now!
