### PR TITLE
Add scripts necessary for CD and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,37 @@ stored in a PostgreSQL database hosted by
 
 ## Launch on AWS
 
-* Create an t2.medium EC2 instance based on Ubuntu 18
-* `sudo apt-get update`
-* `sudo apt-get install -y python3-pip`
-* clone this repo
+* Create an t2.large EC2 instance based on Ubuntu 18. Storage should be 32+ GB.
+* Make sure to open port 80.
+* `sudo apt update`
+* `sudo apt install -y python3-pip`
+* `sudo apt install -y postgresql`
+* `sudo apt install -y unzip`
+* Clone this repo.
+* `cd clashboard`
 * `sudo pip3 install -r requirements.txt`
 * Create a file `.env` with the following:
 
   ```
-  hostname=aact-db.ctti-clinicaltrials.org
+  hostname=localhost
   port=5432
   database=aact
-  username=your_username
+  username=postgres
   password=your_password
 
   ```
-* sudo gunicorn app:app.server
 
+* [Here](https://aact.ctti-clinicaltrials.org/snapshots) we can access a walkthrough to setting up the database and [here](https://help.ubuntu.com/stable/serverguide/postgresql.html) we can get information on configuring the database. First we want to set up the database user and password:
+* `sudo -u postgres psql template1`
+* `ALTER USER postgres with password 'your_password';`
+
+* After configuring the password, edit the file `/etc/postgresql/10/main/pg_hba.conf` to use MD5 authentication with the postgres user:
+`local all postgres md5`
+
+* `sudo systemctl restart postgresql.service`
+
+* We retrieve the most recent data with the following command `sudo ./get_most_recent_data.sh`
+
+* To add the schema that AACT tables are saved in: `psql aact` and then `alter role your-username in database aact set search_path = ctgov, public;`
+
+* To launch the flask application: `sudo gunicorn clashboard_gui:app.server`

--- a/README.md
+++ b/README.md
@@ -71,4 +71,6 @@ stored in a PostgreSQL database hosted by
 
 * To add the schema that AACT tables are saved in: `psql aact` and then `alter role your-username in database aact set search_path = ctgov, public;`
 
-* To launch the flask application: `sudo gunicorn clashboard_gui:app.server`
+* To launch the flask application first we copy `clashboard.service` to the directory `/etc/systemd/system`. Next, we run the following commands: 
+* `sudo systemctl start clashboard`
+* `sudo systemctl enable clashboard`

--- a/scripts/clashboard.service
+++ b/scripts/clashboard.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Start clashboard on Boot
+After=multi-user.target
+
+[Service]
+Type=idle
+ExecStart=/usr/local/bin/gunicorn -b 0.0.0.0:80 --chdir /home/ubuntu/clashboard/src/clashboard/ clashboard_gui:app
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,3 @@
+sudo systemctl stop clashboard
+cd /home/ubuntu/clashboard/ && git pull origin master
+sudo systemctl start clashboard

--- a/src/clashboard/clashboard_gui.py
+++ b/src/clashboard/clashboard_gui.py
@@ -181,4 +181,4 @@ def update_plot(value, n, chart_type):
 
 
 if __name__ == '__main__':
-    app.run_server(host='0.0.0.0')
+    app.run_server(host='0.0.0.0', port=80)


### PR DESCRIPTION
Adds deploy.sh which will allow us to automate deployment and clashboard.service will start clashboard on boot.